### PR TITLE
Added object builder for grafana

### DIFF
--- a/extras/example.jsonnet
+++ b/extras/example.jsonnet
@@ -6,3 +6,4 @@ local kp = (import 'operator/jsonnet/kube-prometheus.libsonnet') + {
 
 { ['00namespace-' + name]: kp.kubePrometheus[name] for name in std.objectFields(kp.kubePrometheus) } +
 { ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) }
+{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) }

--- a/extras/operator/jsonnet/grafana.libsonnet
+++ b/extras/operator/jsonnet/grafana.libsonnet
@@ -1,0 +1,17 @@
+local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+
+{
+  _config+:: {
+    namespace: 'default',
+  },
+  grafana+:: {
+    dashboardDefinitions:
+      local configMap = k.core.v1.configMap;
+      [
+        local dashboardName = 'grafana-dashboard-' + std.strReplace(name, '.json', '');
+        configMap.new(dashboardName, { [name]: std.manifestJsonEx($._config.grafana.dashboards[name], '    ') }) +
+        configMap.mixin.metadata.withNamespace($._config.namespace)
+        for name in std.objectFields($._config.grafana.dashboards)
+      ],
+  },
+}

--- a/extras/operator/jsonnet/kube-prometheus.libsonnet
+++ b/extras/operator/jsonnet/kube-prometheus.libsonnet
@@ -1,10 +1,14 @@
 local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 local configMapList = k.core.v1.configMapList;
 
+(import 'grafana.libsonnet') +
 (import 'prometheus.libsonnet') +
 (import 'gluster-mixins/mixin.libsonnet') + {
   kubePrometheus+:: {
     namespace: k.core.v1.namespace.new($._config.namespace),
+  },
+  grafana+:: {
+    dashboardDefinitions: configMapList.new(super.dashboardDefinitions),
   },
 } + {
   _config+:: {
@@ -12,6 +16,9 @@ local configMapList = k.core.v1.configMapList;
 
     prometheus+:: {
       rules: $.prometheusRules + $.prometheusAlerts,
+    },
+    grafana+:: {
+      dashboards: $.grafanaDashboards,
     },
   },
 }


### PR DESCRIPTION
Grafana builder is required to create a k8s object. The object is of config type and can be applied directly on the k8s cluster.

The file that will be created out of it will have a k8s header with the grafana JSON. After applying you can see the grafana dashboards. 

issue: https://github.com/gluster/gluster-mixins/issues/33
Signed-off-by: Ankush Behl <cloudbehl@gmail.com>